### PR TITLE
fix: registry issue if the value is none

### DIFF
--- a/packages/shared/src/addProjectDetails.js
+++ b/packages/shared/src/addProjectDetails.js
@@ -10,7 +10,7 @@ module.exports = (projectName, { registry, owner }) => {
 
     // Update basic details based on the options chosen
     package.author = owner || '';
-    if (registry) {
+    if (registry && registry !== `none`) {
         package.name = `@${owner}/${projectName}`;
         package.repository = {
             type: 'git',


### PR DESCRIPTION
affects: @medly/starter-shared

# PR Checklist

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

If we pass `registry` as `none` than it fails in copying the project details.

## What is the new behavior?

Added a check for the `none` value.

## Fixes #<issue_number>

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

