### PR TITLE
fix: add npm run in case of package manager as npm

### DIFF
--- a/packages/shared/src/installDependencies.js
+++ b/packages/shared/src/installDependencies.js
@@ -13,7 +13,7 @@ module.exports = packageManager => {
     package.devDependencies = {};
 
     // Change command based on the package manager choice
-    package = JSON.parse(JSON.stringify(package).replace(/yarn/g, packageManager));
+    package = JSON.parse(JSON.stringify(package).replace(/yarn/g, packageManager === 'npm' ? 'npm run' : packageManager));
 
     // Write updated package.json
     fs.writeJSONSync(path.join('package.json'), package, {


### PR DESCRIPTION
affects: @medly/starter-shared

# PR Checklist

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

If we choose package manager as npm, then `run` is missing in all the npm scripts and hence all the scripts fails. 

## What is the new behavior?

Add `npm run` in case of package manager as `npm`.

## Fixes #<issue_number>

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No