### PR TITLE
fix: fireEvent import issue by importing latest @testing-library/dom

### DIFF
--- a/packages/app/template/common/template.json
+++ b/packages/app/template/common/template.json
@@ -21,10 +21,7 @@
         "dist:analyze": "npm run dist -- --analyze"
     },
     "lint-staged": {
-        "src/**/*.{ts,tsx}": [
-            "eslint 'src/**/*.tsx' --fix",
-            "stylelint 'src/**/*.tsx' --fix"
-        ]
+        "src/**/*.{ts,tsx}": ["eslint 'src/**/*.tsx' --fix", "stylelint 'src/**/*.tsx' --fix"]
     },
     "babel": {
         "extends": "@medly/babel-config-react"
@@ -58,6 +55,7 @@
         "@medly/typescript-config-react@latest",
         "@medly/webpack-config@latest",
         "@medly/jest-config-react@latest",
+        "@testing-library/dom@latest",
         "@testing-library/react@latest",
         "@types/react@latest",
         "@types/react-dom@latest",

--- a/packages/app/template/stateManagers/redux/template.json
+++ b/packages/app/template/stateManagers/redux/template.json
@@ -58,6 +58,7 @@
         "@medly/typescript-config-react@latest",
         "@medly/webpack-config@latest",
         "@medly/jest-config-react@latest",
+        "@testing-library/dom@latest",
         "@testing-library/react@latest",
         "@types/react@latest",
         "@types/react-dom@latest",

--- a/packages/component/template/template.json
+++ b/packages/component/template/template.json
@@ -83,6 +83,7 @@
         "@storybook/addon-links@latest",
         "@storybook/react@latest",
         "@storybook/storybook-deployer@latest",
+        "@testing-library/dom@latest",
         "@testing-library/react@latest",
         "@types/react@latest",
         "@types/react-dom@latest",


### PR DESCRIPTION
affects: @medly/create-app, @medly/create-component

# PR Checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`fireEvent` is moved to `@testing-library/dom`, hence importing `fireEvent` from `@tesing-library/react` is failing.

## What is the new behavior?

Added `@testing-library/dom` also.

## Fixes #<issue_number>

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No